### PR TITLE
use fsnotify.v0

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 	"path"
 	"strings"
 
-	"code.google.com/p/go.exp/fsnotify"
 	"github.com/mirtchovski/gosxnotifier"
+	"gopkg.in/fsnotify.v0"
 )
 
 var dir = flag.String("dir", "/Library/Logs/DiagnosticReports/:~/Library/Logs/DiagnosticReports", "column-separated list of directories to monitor")


### PR DESCRIPTION
fsnotify is currently being maintained at: https://github.com/go-fsnotify/fsnotify

fsnotify.v0 matches the API you are using but some bugs have been fixed. There
is also a newer v1 API if you wish to upgrade.

(So I know when this is merged, ref: https://github.com/go-fsnotify/fsnotify/issues/35)
